### PR TITLE
onFeedbackSubmit disable button

### DIFF
--- a/src/components/AcceptProposalForm.tsx
+++ b/src/components/AcceptProposalForm.tsx
@@ -12,12 +12,16 @@ interface AcceptProposalFormProps {
   proposalName: string
   proposalId: string
   supervisorEmail: string
+  feedbackGiven: boolean
+  setFeedbackGiven: (value: boolean) => void
 }
 
 export default function AcceptProposalForm({
   proposalName,
   proposalId,
   supervisorEmail,
+  feedbackGiven,
+  setFeedbackGiven,
 }: AcceptProposalFormProps) {
   const SignupSchema = Yup.object().shape({
     comment: Yup.string().required('Required'),
@@ -36,8 +40,8 @@ export default function AcceptProposalForm({
       }}
       validationSchema={SignupSchema}
       onSubmit={async (values, { resetForm }) => {
+        setFeedbackGiven(true)
         await submitFeedback.mutateAsync(values)
-
         resetForm()
         toast.success('Proposal accepted successfully!')
       }}
@@ -74,7 +78,11 @@ export default function AcceptProposalForm({
           </div>
         </div>
 
-        <Button className={{ root: 'mt-2' }} type="submit">
+        <Button
+          className={{ root: 'mt-2' }}
+          type="submit"
+          disabled={feedbackGiven}
+        >
           Accept Proposal
         </Button>
         <Toaster />

--- a/src/components/DeclineProposalForm.tsx
+++ b/src/components/DeclineProposalForm.tsx
@@ -13,12 +13,16 @@ interface DeclineProposalFormProps {
   proposalName: string
   proposalId: string
   supervisorEmail: string
+  feedbackGiven: boolean
+  setFeedbackGiven: (value: boolean) => void
 }
 
 export default function DeclineProposalForm({
   proposalName,
   proposalId,
   supervisorEmail,
+  feedbackGiven,
+  setFeedbackGiven,
 }: DeclineProposalFormProps) {
   const SignupSchema = Yup.object().shape({
     reason: Yup.string().required('Required'),
@@ -39,8 +43,8 @@ export default function DeclineProposalForm({
       }}
       validationSchema={SignupSchema}
       onSubmit={async (values, { resetForm }) => {
+        setFeedbackGiven(true)
         await submitFeedback.mutateAsync(values)
-
         resetForm()
         toast.success('Proposal declined successfully!')
       }}
@@ -99,7 +103,11 @@ export default function DeclineProposalForm({
           </div>
         </div>
 
-        <Button className={{ root: 'mt-2' }} type="submit">
+        <Button
+          className={{ root: 'mt-2' }}
+          type="submit"
+          disabled={feedbackGiven}
+        >
           Decline Proposal
         </Button>
         <Toaster />

--- a/src/components/ProposalStatusForm.tsx
+++ b/src/components/ProposalStatusForm.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from '@uzh-bf/design-system'
 import type { Session } from 'next-auth'
+import { useState } from 'react'
 import { ProposalDetails } from 'src/types/app'
 import AcceptProposalForm from './AcceptProposalForm' // Import AcceptProposalForm and other form components
 import DeclineProposalForm from './DeclineProposalForm'
@@ -14,6 +15,8 @@ export default function ProposalStatusForm({
   proposalDetails,
   session,
 }: ProposalStatusFormProps) {
+  const [feedbackGiven, setFeedbackGiven] = useState(false)
+  const [feedbackGivenTentative, setFeedbackGivenTentative] = useState(false)
   if (
     proposalDetails?.typeKey === 'STUDENT' &&
     proposalDetails?.statusKey === 'MATCHED_TENTATIVE'
@@ -44,6 +47,8 @@ export default function ProposalStatusForm({
                 proposalName={proposalDetails?.title}
                 proposalId={proposalDetails?.id}
                 supervisorEmail={session?.user?.email as string}
+                feedbackGiven={feedbackGiven}
+                setFeedbackGiven={setFeedbackGiven}
               />
             </Tabs.TabContent>
             <Tabs.TabContent
@@ -58,6 +63,8 @@ export default function ProposalStatusForm({
                 proposalName={proposalDetails?.title}
                 proposalId={proposalDetails?.id}
                 supervisorEmail={session?.user?.email as string}
+                feedbackGiven={feedbackGiven}
+                setFeedbackGiven={setFeedbackGiven}
               />
             </Tabs.TabContent>
           </Tabs>
@@ -102,6 +109,8 @@ export default function ProposalStatusForm({
               proposalName={proposalDetails?.title}
               proposalId={proposalDetails?.id}
               supervisorEmail={session?.user?.email as string}
+              feedbackGiven={feedbackGiven}
+              setFeedbackGiven={setFeedbackGiven}
             />
           </Tabs.TabContent>
           <Tabs.TabContent
@@ -116,6 +125,8 @@ export default function ProposalStatusForm({
               proposalName={proposalDetails?.title}
               proposalId={proposalDetails?.id}
               supervisorEmail={session?.user?.email as string}
+              feedbackGivenTentative={feedbackGivenTentative}
+              setFeedbackGivenTentative={setFeedbackGivenTentative}
             />
           </Tabs.TabContent>
           <Tabs.TabContent
@@ -130,6 +141,8 @@ export default function ProposalStatusForm({
               proposalName={proposalDetails?.title}
               proposalId={proposalDetails?.id}
               supervisorEmail={session?.user?.email as string}
+              feedbackGiven={feedbackGiven}
+              setFeedbackGiven={setFeedbackGiven}
             />
           </Tabs.TabContent>
           <Tabs.TabContent
@@ -144,6 +157,8 @@ export default function ProposalStatusForm({
               proposalName={proposalDetails?.title}
               proposalId={proposalDetails?.id}
               supervisorEmail={session?.user?.email as string}
+              feedbackGiven={feedbackGiven}
+              setFeedbackGiven={setFeedbackGiven}
             />
           </Tabs.TabContent>
         </Tabs>

--- a/src/components/RejectProposalForm.tsx
+++ b/src/components/RejectProposalForm.tsx
@@ -13,12 +13,16 @@ interface RejectProposalFormProps {
   proposalName: string
   proposalId: string
   supervisorEmail: string
+  feedbackGiven: boolean
+  setFeedbackGiven: (value: boolean) => void
 }
 
 export default function RejectProposalForm({
   proposalName,
   proposalId,
   supervisorEmail,
+  feedbackGiven,
+  setFeedbackGiven,
 }: RejectProposalFormProps) {
   const SignupSchema = Yup.object().shape({
     reason: Yup.string().required('Required'),
@@ -39,8 +43,8 @@ export default function RejectProposalForm({
       }}
       validationSchema={SignupSchema}
       onSubmit={async (values, { resetForm }) => {
+        setFeedbackGiven(true)
         await submitFeedback.mutateAsync(values)
-
         resetForm()
         toast.success('Proposal rejected successfully!')
       }}
@@ -105,7 +109,11 @@ export default function RejectProposalForm({
           </div>
         </div>
 
-        <Button className={{ root: 'mt-2' }} type="submit">
+        <Button
+          className={{ root: 'mt-2' }}
+          type="submit"
+          disabled={feedbackGiven}
+        >
           Reject Proposal
         </Button>
         <Toaster />

--- a/src/components/TentativeAcceptProposalForm.tsx
+++ b/src/components/TentativeAcceptProposalForm.tsx
@@ -12,12 +12,16 @@ interface TentativeAcceptProposalFormProps {
   proposalName: string
   proposalId: string
   supervisorEmail: string
+  feedbackGivenTentative: boolean
+  setFeedbackGivenTentative: (value: boolean) => void
 }
 
 export default function TentativeAcceptProposalForm({
   proposalName,
   proposalId,
   supervisorEmail,
+  feedbackGivenTentative,
+  setFeedbackGivenTentative,
 }: TentativeAcceptProposalFormProps) {
   const SignupSchema = Yup.object().shape({
     comment: Yup.string().required('Required'),
@@ -36,8 +40,8 @@ export default function TentativeAcceptProposalForm({
       }}
       validationSchema={SignupSchema}
       onSubmit={async (values, { resetForm }) => {
+        setFeedbackGivenTentative(true)
         await submitFeedback.mutateAsync(values)
-
         resetForm()
         toast.success('Proposal tentatively accepted successfully!')
       }}
@@ -73,7 +77,11 @@ export default function TentativeAcceptProposalForm({
           </div>
         </div>
 
-        <Button className={{ root: 'mt-2' }} type="submit">
+        <Button
+          className={{ root: 'mt-2' }}
+          type="submit"
+          disabled={feedbackGivenTentative}
+        >
           Accept Proposal (Tentative)
         </Button>
         <Toaster />


### PR DESCRIPTION
disable button - such that supervisors cannot double or tripple submit the same feedback... only problem --> with my implementation all other submit buttons (other proposals) are also disabled until the site is out & back in focus or reloaded.. other solution from your side? @rschlaefli 