### PR TITLE
feat(app): Proposal Application Acceptance Workflow Added

### DIFF
--- a/src/components/ProposalApplication.tsx
+++ b/src/components/ProposalApplication.tsx
@@ -1,5 +1,6 @@
 import { H2, Table } from '@uzh-bf/design-system'
 import { add, format, parseISO } from 'date-fns'
+import { useState } from 'react'
 import { ApplicationDetails, ProposalDetails } from 'src/types/app'
 import ApplicationDetailsModal from './ApplicationDetailsModal'
 import ApplicationForm from './ApplicationForm'
@@ -15,6 +16,8 @@ export default function ProposalApplication({
   isStudent,
   isSupervisor,
 }: ProposalApplicationProps) {
+  const [isProposalOpen, setIsProposalOpen] = useState<boolean>(true)
+
   if (proposalDetails?.typeKey === 'SUPERVISOR') {
     return (
       <div className="p-4">
@@ -66,7 +69,11 @@ export default function ProposalApplication({
                     label: 'Details',
                     accessor: 'details',
                     transformer: ({ row }) => (
-                      <ApplicationDetailsModal row={row} />
+                      <ApplicationDetailsModal
+                        row={row}
+                        isProposalOpen={isProposalOpen}
+                        setIsProposalOpen={setIsProposalOpen}
+                      />
                     ),
                   },
                 ]}

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -242,6 +242,21 @@ export const appRouter = router({
     .mutation(async ({ ctx, input }) => {
       const res = await axios.post(process.env.APPLICATION_URL as string, input)
     }),
+
+  acceptProposalApplication: publicProcedure
+    .input(
+      z.object({
+        proposalId: z.string(),
+        proposalApplicationId: z.string(),
+        applicantEmail: z.string().email(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const res = await axios.post(
+        process.env.APPLICATION_ACCEPTANCE_URL as string,
+        input
+      )
+    }),
 })
 
 export type AppRouter = typeof appRouter


### PR DESCRIPTION
The Proposal Application Acceptance Workflow was added. The accept button is right now placed inside the modal (design-wise not final but to show that it works). On accept -> state of Open Proposal changes immediately -> "Refresh page notification" -> application gets accepted & all other applications for the same Supervisor Proposal get rejected (see Solution implementation).