### PR TITLE
enhance(app): show supervisor proposals for all Supervisors but only show applications for owner/supervisor 

### DIFF
--- a/src/components/ApplicationForm.tsx
+++ b/src/components/ApplicationForm.tsx
@@ -183,6 +183,7 @@ export default function ApplicationForm({
             onDrop={handleFileFieldChange('cvFile', 'cv', formikProps)}
             multiple={false}
             accept={{ 'application/pdf': ['.pdf'] }}
+            disabled={!formikProps.values.uzhemail.endsWith('uzh.ch')}
           >
             {({ getRootProps, getInputProps }) => (
               <section>
@@ -192,7 +193,9 @@ export default function ApplicationForm({
                 >
                   <input type="file" {...getInputProps()} />
                   <p className="p-2 text-base">
-                    {cv.length > 0
+                    {!formikProps.values.uzhemail.endsWith('uzh.ch')
+                      ? 'Enter your UZH Email before uploading files ⚠️'
+                      : cv.length > 0
                       ? `Attached File 📄: '${cv[0].name}'`
                       : 'Drag and drop your file 🗃️ here, or click to select the file'}
                   </p>
@@ -212,6 +215,7 @@ export default function ApplicationForm({
             )}
             multiple={false}
             accept={{ 'application/pdf': ['.pdf'] }}
+            disabled={!formikProps.values.uzhemail.endsWith('uzh.ch')}
           >
             {({ getRootProps, getInputProps }) => (
               <section>
@@ -221,7 +225,9 @@ export default function ApplicationForm({
                 >
                   <input type="file" {...getInputProps()} />
                   <p className="p-2 text-base">
-                    {transcript.length > 0
+                    {!formikProps.values.uzhemail.endsWith('uzh.ch')
+                      ? 'Enter your UZH Email before uploading files ⚠️'
+                      : transcript.length > 0
                       ? `Attached File 📄: '${transcript[0].name}'`
                       : 'Drag and drop your file 🗃️ here, or click to select the file'}
                   </p>

--- a/src/components/ProposalApplication.tsx
+++ b/src/components/ProposalApplication.tsx
@@ -43,7 +43,7 @@ export default function ProposalApplication({
         {isSupervisor &&
         (session?.user?.email === proposalDetails?.ownedByUserEmail ||
           session?.user.email ===
-            proposalDetails.supervisedBy[0].supervisorEmail) ? (
+            proposalDetails?.supervisedBy?.[0].supervisorEmail) ? (
           <div className="pt-4">
             <H2>Applications</H2>
             {proposalDetails?.applications?.length === 0 &&

--- a/src/components/ProposalApplication.tsx
+++ b/src/components/ProposalApplication.tsx
@@ -112,9 +112,11 @@ export default function ProposalApplication({
             )}
           </div>
         ) : (
-          <div className="bg-yellow-100">
-            You are not allowed to see any applications to this proposal.
-          </div>
+          isSupervisor && (
+            <div className="bg-yellow-100">
+              You are not allowed to see any applications to this proposal.
+            </div>
+          )
         )}
       </div>
     )

--- a/src/components/ProposalApplication.tsx
+++ b/src/components/ProposalApplication.tsx
@@ -1,5 +1,6 @@
 import { H2, Table } from '@uzh-bf/design-system'
 import { add, format, parseISO } from 'date-fns'
+import { useSession } from 'next-auth/react'
 import { useState } from 'react'
 import { trpc } from 'src/lib/trpc'
 import { ApplicationDetails, ProposalDetails } from 'src/types/app'
@@ -26,6 +27,7 @@ export default function ProposalApplication({
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] =
     useState<boolean>(false)
 
+  const { data: session } = useSession()
   const acceptApplication = trpc.acceptProposalApplication.useMutation()
 
   if (proposalDetails?.typeKey === 'SUPERVISOR') {
@@ -38,7 +40,10 @@ export default function ProposalApplication({
             proposalId={proposalDetails.id}
           />
         )}
-        {isSupervisor && (
+        {isSupervisor &&
+        (session?.user?.email === proposalDetails?.ownedByUserEmail ||
+          session?.user.email ===
+            proposalDetails.supervisedBy[0].supervisorEmail) ? (
           <div className="pt-4">
             <H2>Applications</H2>
             {proposalDetails?.applications?.length === 0 &&
@@ -105,6 +110,10 @@ export default function ProposalApplication({
                 data={proposalDetails?.applications}
               />
             )}
+          </div>
+        ) : (
+          <div className="bg-yellow-100">
+            You are not allowed to see any applications to this proposal.
           </div>
         )}
       </div>

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -55,6 +55,27 @@ async function getSupervisorProposals({ ctx, filters }) {
       },
     }
     applications = {
+      where: {
+        proposal: {
+          OR: [
+            {
+              typeKey: {
+                in: ['STUDENT'],
+              },
+            },
+            {
+              ownedByUserEmail: ctx.user?.email,
+            },
+            {
+              supervisedBy: {
+                some: {
+                  supervisorEmail: ctx.user?.email,
+                },
+              },
+            },
+          ],
+        },
+      },
       include: {
         attachments: true,
         status: true,
@@ -83,7 +104,7 @@ async function getSupervisorProposals({ ctx, filters }) {
         {
           statusKey: ProposalStatus.OPEN,
           typeKey: {
-            in: ['STUDENT'],
+            in: ['STUDENT', 'SUPERVISOR'],
           },
         },
         { ownedByUserEmail: ctx.user?.email },
@@ -108,26 +129,7 @@ async function getSupervisorProposals({ ctx, filters }) {
   if (filters.status === ProposalStatusFilter.OPEN_PROPOSALS) {
     where = {
       ...where,
-      OR: [
-        {
-          statusKey: ProposalStatus.OPEN,
-          typeKey: {
-            in: ['STUDENT'],
-          },
-        },
-        {
-          statusKey: ProposalStatus.OPEN,
-          ownedByUserEmail: ctx.user?.email,
-        },
-        {
-          statusKey: ProposalStatus.OPEN,
-          supervisedBy: {
-            some: {
-              supervisorEmail: ctx.user?.email,
-            },
-          },
-        },
-      ],
+      statusKey: ProposalStatus.OPEN,
       NOT: {
         receivedFeedbacks: {
           some: {


### PR DESCRIPTION
This pull request enhances the application by refining the visibility of proposals and applications within the app. The changes ensure a more streamlined display for different user roles:

- **Supervisor Proposals Visibility**: All supervisors can now view proposals within the system.
- **Applications Visibility**: Applications are now limited to display only for the initial owner of the proposal (owner or topic supervisor)