### PR TITLE
Fix: Ensure My Active Proposals filter only shows proposals supervised by current user

### DIFF
--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -187,6 +187,11 @@ async function getSupervisorProposals({ ctx, filters }) {
           statusKey: ProposalStatus.MATCHED,
           updatedAt: {
             gte: sixMonthsAgo
+          },
+          supervisedBy: {
+            some: {
+              supervisorEmail: ctx.user?.email
+            }
           }
         },
         {


### PR DESCRIPTION
This PR fixes an issue with the "My Active Proposals" filter where it was showing proposals accepted by other users. The fix ensures that only proposals supervised by the current user are displayed when this filter is selected.