### PR TITLE
feat: add CleverReach API integration via Power Automate

### DIFF
--- a/bruno/Thesis/Cleverreach Call.bru
+++ b/bruno/Thesis/Cleverreach Call.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Cleverreach Call
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://prod-26.switzerlandnorth.logic.azure.com:443/workflows/b63f15d8297848638ff53bb415cd718c/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=wxbVQoHIHheWa94H6qg5MRBKa_dHS1HATc5lAjndsJU
+  body: json
+  auth: none
+}
+
+params:query {
+  api-version: 2016-06-01
+  sp: %2Ftriggers%2Fmanual%2Frun
+  sv: 1.0
+  sig: wxbVQoHIHheWa94H6qg5MRBKa_dHS1HATc5lAjndsJU
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "flow_secret": "abcd",
+    "template_name": "TEST",
+    "html_variables_to_replace": [{
+      "key": "____CUSTOM_TEXT____",
+      "value": "WAUW!"}, {"key": "Spannende Ausschreibungen auf der Theses Plattform", "value": "COOOOOL!"}],
+    "sender_email": "maximilian.weber@bluewin.ch",
+    "sender_name": "Max",
+    "subject": "ABC",
+    "receiver_group_id": "571328",
+    "mailing_name": "TEST_123"
+  }
+}
+
+settings {
+  encodeUrl: false
+}


### PR DESCRIPTION
## What
Added Bruno HTTP client configuration for CleverReach mailing API integration through Power Automate workflow.

## Why
Enables automated email campaigns and mailing functionality using CleverReach service for the thesis project.

## How
- Created Bruno API collection file for CleverReach calls
- Configured POST request to Power Automate webhook endpoint
- Set up JSON payload with email template variables, sender info, and recipient group
- Includes dynamic HTML variable replacement for personalized emails

## Key Features
- Template-based email system with variable substitution
- Configurable sender details and subject lines
- Receiver group targeting (ID: 571328)
- Custom HTML content replacement functionality

## Testing
Ready for API testing through Bruno client with the configured Power Automate endpoint and payload structure.