### PR TITLE
feat: sort supervisor proposals by topic area

### DIFF
--- a/src/components/SupervisorProposals.tsx
+++ b/src/components/SupervisorProposals.tsx
@@ -18,6 +18,12 @@ export default function SupervisorProposals({
     return [
       ...data.filter((proposal) => proposal.typeKey === 'SUPERVISOR'),
     ].sort((a, b) => {
+      const topicAreaCompare = a.topicArea.name.localeCompare(b.topicArea.name)
+
+      if (topicAreaCompare !== 0) {
+        return topicAreaCompare
+      }
+
       const createdAtCompare =
         new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
 


### PR DESCRIPTION
## Summary
- Group supervisor proposals on the overview by topic area (category) so related topics appear together
- Falls back to creation date and then title for stable ordering within a category

## Why
Supervisor proposals on the overview were sorted by `createdAt` then `title`, so topics from the same area were scattered through the list. Sorting by topic area first makes the list easier to scan when looking for proposals in a specific area.

## Test plan
- [ ] Open the overview page as a supervisor/student
- [ ] Confirm supervisor proposals are grouped by topic area name (alphabetical)
- [ ] Within a topic area, confirm older proposals come first and ties break by title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sorting of supervisor proposals to prioritize topic area ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->