### PR TITLE
Count only active supervised theses in admin statistics

### DIFF
--- a/src/components/AdminStatsDashboard.tsx
+++ b/src/components/AdminStatsDashboard.tsx
@@ -206,11 +206,13 @@ export default function AdminStatsDashboard() {
           <div>
             <h2 className="text-lg font-semibold text-gray-900">Statistics</h2>
             <p className="mt-1 text-sm text-gray-600">
-              Supervised proposals per year (grouped by supervisor or responsible)
+              Active supervised theses per year (grouped by supervisor or responsible)
             </p>
           </div>
           <div className="text-xs text-gray-600">
-            {isLoading ? 'Loading…' : `${viewTotal} supervised in ${selectedYear}`}
+            {isLoading
+              ? 'Loading…'
+              : `${viewTotal} active supervised theses in ${selectedYear}`}
           </div>
         </div>
 

--- a/src/server/routers/_app.ts
+++ b/src/server/routers/_app.ts
@@ -3037,11 +3037,18 @@ updateProposalStatus: publicProcedure
     .input(z.object({ year: z.number().int().optional() }).optional())
     .query(async ({ input }) => {
       const envDepartment = process.env.NEXT_PUBLIC_DEPARTMENT_NAME as Department
+      const activeSupervisionStatuses = [
+        ProposalStatus.MATCHED,
+        ProposalStatus.MATCHED_TENTATIVE,
+      ]
 
       const supervisionDates = await prisma.userProposalSupervision.findMany({
         where: {
           proposal: {
             department: envDepartment,
+            statusKey: {
+              in: activeSupervisionStatuses,
+            },
           },
         },
         select: {
@@ -3069,6 +3076,9 @@ updateProposalStatus: publicProcedure
             },
             proposal: {
               department: envDepartment,
+              statusKey: {
+                in: activeSupervisionStatuses,
+              },
             },
           },
           select: {


### PR DESCRIPTION
## Summary
- Exclude `WITHDRAWN` and `OPEN` proposals from the supervision statistics.
- Treat only `MATCHED` and `MATCHED_TENTATIVE` as active supervised theses.
- Update the admin stats copy to match the new meaning of the metric.

## Testing
- Ran `pnpm lint` successfully.
- Verified against production data that the 2026 total drops to the active supervision count and Roland Schlaefli no longer appears in the statistic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Dashboard header label updated to "Active supervised theses per year"
  * Admin supervision statistics now filter to show only active supervised theses, excluding inactive records from the dataset

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uzh-bf/thesis-platform/pull/97)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->