### PR TITLE
feat: add secret name definition for application environment variables

### DIFF
--- a/deploy/chart_new/templates/_helpers.tpl
+++ b/deploy/chart_new/templates/_helpers.tpl
@@ -24,6 +24,13 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Create the name of the Secret used for application environment variables.
+*/}}
+{{- define "thesis-platform.secretName" -}}
+{{- default (include "thesis-platform.fullname" .) .Values.secretName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "thesis-platform.chart" -}}

--- a/deploy/chart_new/templates/deployment.yaml
+++ b/deploy/chart_new/templates/deployment.yaml
@@ -33,6 +33,6 @@ spec:
               protocol: TCP
           envFrom:
             - secretRef:
-                name: {{ include "thesis-platform.fullname" . }}
+                name: {{ include "thesis-platform.secretName" . }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/chart_new/values.yaml
+++ b/deploy/chart_new/values.yaml
@@ -9,6 +9,8 @@ service:
   type: ClusterIP
   port: 3000
 
+secretName: ""
+
 ingress:
   enabled: true
   annotations:

--- a/deploy/stg_new/values.yaml
+++ b/deploy/stg_new/values.yaml
@@ -1,6 +1,8 @@
 image:
   tag: 'latest-arm-39a79957ecff50a3b0f90a0c62edfb3d2a569e37'
 
+secretName: stg-thesisplatform-secrets
+
 ingress:
   hosts:
     - host: theses.stg.df-app.ch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Helm chart templates to enable configurable secret names for application environment variables
  * Added new configuration option allowing operators to override default secret naming behavior for greater deployment flexibility across environments
  * Maintains backward compatibility using chart-based naming conventions when custom secrets are not specified
  * Updated staging deployment to use environment-specific secret configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->