### PR TITLE
feat(deploy): auto-run DB migrations on every deploy (stg + prd)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,11 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Prisma CLI, schema and migrations so the deploy migration job can run
+# "prisma migrate deploy" with this image (version must match package.json)
+RUN npm install -g prisma@6.15.0
+COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma
+
 USER nextjs
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # Prisma CLI, schema and migrations so the deploy migration job can run
-# "prisma migrate deploy" with this image (version must match package.json)
+# "prisma migrate deploy" with this image (version must match package.json);
+# owned by root so they stay read-only for the runtime user
 RUN npm install -g prisma@6.15.0
-COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma
+COPY --from=builder /app/prisma ./prisma
 
 USER nextjs
 

--- a/deploy/chart_new/templates/migration-job.yaml
+++ b/deploy/chart_new/templates/migration-job.yaml
@@ -17,6 +17,7 @@ spec:
         app: {{ include "thesis-platform.fullname" . }}-migrate
     spec:
       restartPolicy: Never
+      automountServiceAccountToken: false
       containers:
         - name: migrate
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/deploy/chart_new/templates/migration-job.yaml
+++ b/deploy/chart_new/templates/migration-job.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "thesis-platform.fullname" . }}-migrate
+  labels:
+    {{- include "thesis-platform.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app: {{ include "thesis-platform.fullname" . }}-migrate
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['prisma', 'migrate', 'deploy']
+          envFrom:
+            - secretRef:
+                name: {{ include "thesis-platform.secretName" . }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}

--- a/deploy/chart_new/values.yaml
+++ b/deploy/chart_new/values.yaml
@@ -43,5 +43,14 @@ resources:
     memory: 256Mi
     cpu: 200m
 
+migration:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 200m
+    limits:
+      memory: 1024Mi
+      cpu: 1000m
+
 annotations: {}
 podAnnotations: {}


### PR DESCRIPTION
## What changed

- **New `deploy/chart_new/templates/migration-job.yaml`** — a Kubernetes Job with ArgoCD `PreSync` hook annotations (`hook-delete-policy: BeforeHookCreation,HookSucceeded`, `backoffLimit: 1`, 600s deadline, 1h TTL). On every ArgoCD sync it runs `prisma migrate deploy` with the app image **before** the new deployment rolls out. It reads `DATABASE_URL` from the same env secret as the app, so stg and prd each migrate their own database.
- **Dockerfile** — the runtime image is a Next.js standalone build with no Prisma in it, so the runner stage now installs the Prisma CLI globally (pinned to `6.15.0`, matching `package.json` — keep in sync when upgrading) and copies `prisma/` (schema + migrations) into the image. Engine binaries are downloaded at image build time; the job needs no network access at runtime.
- **`deploy/chart_new/values.yaml`** — adds a `migration.resources` block for the job.

## Why

Database migrations currently have to be applied manually (`pnpm prisma:deploy:stage` / `:prod`). With this change, every main push (stg) and release (prd) that rolls out via ArgoCD automatically applies pending migrations first, in the same image that gets deployed.

## Verification

- `helm template` + `helm lint` pass for both `stg_new` and `prd_new` values; job pods get distinct labels so the Service never routes to them.
- Full Docker image built locally; `prisma migrate deploy` ran from the image (as the `nextjs` user) against a fresh MySQL 8 container: **all 17 migrations applied, exit 0**; a second run is a clean no-op ("No pending migrations to apply"), so re-running on every sync is safe.
- Note: replaying the history from scratch requires MySQL with `lower_case_table_names=1` and `sql_generate_invisible_primary_key=ON` (pre-existing trait of the migration history, matching the real servers — vanilla MySQL fails at migration 2/3).

## Before merging

Please confirm both live DBs are baselined so the first PreSync run is a no-op:

```bash
pnpm script:stage -- prisma migrate status
pnpm script:prod -- prisma migrate status
```

Both should report "Database schema is up to date". If either reports pending-but-actually-applied migrations (e.g. historically maintained via `db push`), baseline once with `prisma migrate resolve --applied <name>` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database migrations now execute automatically during application deployment, eliminating manual post-deployment steps.
  * Streamlined deployment workflow with integrated schema update handling.

* **Chores**
  * Configured infrastructure resources and resource allocation settings for migration operations to optimize performance and ensure reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->